### PR TITLE
fix possible routing conflicts

### DIFF
--- a/src/api/links.rs
+++ b/src/api/links.rs
@@ -90,7 +90,7 @@ async fn get_original_url(pool: Pool<MySql>, code: String) -> Result<String, sql
     Ok(row.0)
 }
 
-#[get("/links")]
+#[get("/links/all")]
 async fn get_all_links(data: web::Data<Pool<MySql>>) -> impl Responder {
     let links = get_links(data.as_ref().clone()).await;
     let links = match links {


### PR DESCRIPTION
There is a bug in the code of this project. The two routes  #[get("/{code}")] and #[get("/links")] will conflict during route matching,
#[get("/{code}")] will be triggered if it is registered before #[get("/links")].

no bug
```
HttpServer::new(move || {
        App::new()
            .app_data(web::Data::new(pool.clone()))
            .service(index)
            .service(api::links::create_link)
            .service(api::links::get_all_links) // #[get("/links")]
            .service(api::links::get_from_link) // #[get("/{code}")]
            .service(api::links::get_origin_url_from_link)
    })
```
bug 
```
HttpServer::new(move || {
        App::new()
            .app_data(web::Data::new(pool.clone()))
            .service(index)
            .service(api::links::create_link)
            .service(api::links::get_from_link) // #[get("/{code}")]
            .service(api::links::get_all_links) // #[get("/links")]
            .service(api::links::get_origin_url_from_link)
    })
```
I don't think the possible problems can be solved by simply replacing the order of route registration
